### PR TITLE
Added config for the maven changes plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,22 @@
 					</reportSet>
 				</reportSets>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-changes-plugin</artifactId>
+				<version>2.12</version>
+				<configuration>
+					<githubAPIScheme>https</githubAPIScheme>
+					<githubAPIPort>443</githubAPIPort>
+				</configuration>
+				<reportSets>
+					<reportSet>
+						<reports>
+							<report>github-report</report>
+						</reports>
+					</reportSet>
+				</reportSets>
+			</plugin>
 		</plugins>
 	</reporting>
 


### PR DESCRIPTION
Once we wish to include an automated change log that can be read by end users, we can enable the maven changes plugin by simply accepting this pull request.

**Please note** that we still need to configure GitHub authentification if we wish to use the plugin.
